### PR TITLE
Remove Go Action Token Input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,6 @@ runs:
     if: inputs.setup-go
     with:
       go-version: ${{ inputs.setup-go }}
-      token: ${{ steps.iat.outputs.instl-token || github.token }}
 
   - name: Setup Java
     uses: inloco/actions-setup-java@HEAD


### PR DESCRIPTION
Remove unused token input to avoid warnings during workflow runs.

<img width="903" alt="Screen Shot 2022-04-25 at 5 09 32 PM" src="https://user-images.githubusercontent.com/23530832/165166815-9f8f847f-db33-4879-b92d-a273f4226f0a.png">

Source: https://github.com/inloco/github-checker/actions/runs/2222555625