### PR TITLE
Setup Git Config with Installation Token

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,11 @@ runs:
       app-id: ${{ env.GITHUB_APP_ID }}
       app-pk: ${{ env.GITHUB_APP_PK }}
 
+  - name: Setup Access to Incognia's Private Repositories
+    if: steps.iat.outputs.instl-token
+    run: sudo git config --system url."https://x-access-token:${{ steps.iat.outputs.instl-token }}@github.com/inloco".insteadOf "https://github.com/inloco"
+    shell: bash
+
   - name: Checkout Code with Submodules
     uses: actions/checkout@v2
     if: steps.iat.outputs.instl-token


### PR DESCRIPTION
Allows CI to clone private repositories. For example, this is necessary when installing Go binaries that requires private repositories:

```yaml
- run: go install github.com/actgardner/gogen-avro/v7/cmd/...
- run: go install github.com/go-bindata/go-bindata/...@latest
```
Source: https://github.com/inloco/sdk-config/blob/1b104da79c359beebdc8462b4e51749d51461287/.github/workflows/continuous.yaml#L39-L42

Working example: https://github.com/inloco/sdk-config/actions/runs/2296429323